### PR TITLE
Fix hsl2rgb implementation

### DIFF
--- a/src/rgb-hsv.js
+++ b/src/rgb-hsv.js
@@ -43,18 +43,19 @@ export function hsv2rgb(hsvH, hsvS, hsvV) {
 	const rgbF = hsvH / 60 - rgbI & 1 ? hsvH / 60 - rgbI : 1 - hsvH / 60 - rgbI;
 	const rgbM = hsvV * (100 - hsvS) / 100;
 	const rgbN = hsvV * (100 - hsvS * rgbF) / 100;
+	const rgbT = hsvV * (100 - (100 - rgbF) * hsvS / 100) / 100;
 
 	const [ rgbR, rgbG, rgbB ] = rgbI === 5
 		? [ hsvV, rgbM, rgbN ]
 	: rgbI === 4
-		? [ rgbN, rgbM, hsvV ]
+		? [ rgbT, rgbM, hsvV ]
 	: rgbI === 3
 		? [ rgbM, rgbN, hsvV ]
 	: rgbI === 2
-		? [ rgbM, hsvV, rgbN ]
+		? [ rgbM, hsvV, rgbT ]
 	: rgbI === 1
 		? [ rgbN, hsvV, rgbM ]
-	: [ hsvV, rgbN, rgbM ];
+	: [ hsvV, rgbT, rgbM ];
 
 	return [ rgbR, rgbG, rgbB ];
 }


### PR DESCRIPTION
Resolves #2

If I understand correctly, the [Chinese](https://zh.wikipedia.org/wiki/HSL%E5%92%8CHSV%E8%89%B2%E5%BD%A9%E7%A9%BA%E9%97%B4#%E4%BB%8EHSV%E5%88%B0RGB%E7%9A%84%E8%BD%AC%E6%8D%A2) and [German](https://de.wikipedia.org/wiki/HSV-Farbraum#Umrechnung_HSV_in_RGB) equations are more comprehensible than the [English](https://en.wikipedia.org/wiki/HSL_and_HSV#From_HSV) one, which had led me to incorrectly calculate HSL to RGB conversions.